### PR TITLE
Add support for shorthand CSS properties.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "homepage": "https://github.com/kristoferjoseph/postcss-modular-scale",
   "dependencies": {
     "modular-scale": "^4.4.1",
-    "postcss": "^5.0.2"
+    "postcss": "^5.0.2",
+    "postcss-value-parser": "^3.3.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/test/fixtures/nonsense-values.css
+++ b/test/fixtures/nonsense-values.css
@@ -1,0 +1,9 @@
+:root {
+  --ms-bases: 1, 0.75;
+  --ms-ratios: 2;
+}
+
+.header {
+  font-size: ms(rem)rem;
+}
+

--- a/test/fixtures/shorthand.css
+++ b/test/fixtures/shorthand.css
@@ -1,0 +1,9 @@
+:root {
+  --ms-bases: 1;
+  --ms-ratios: 2;
+}
+
+.header {
+  padding: ms(1)rem ms(2)rem ms(3)rem ms(4)rem;
+}
+

--- a/test/fixtures/shorthand.expected.css
+++ b/test/fixtures/shorthand.expected.css
@@ -1,0 +1,9 @@
+:root {
+  --ms-bases: 1;
+  --ms-ratios: 2;
+}
+
+.header {
+  padding: 2rem 4rem 8rem 16rem;
+}
+

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,14 @@ var test = function (input, output, opts, done) {
     });
 };
 
+var failTest = function (input, output, opts, done) {
+    postcss([ plugin(opts) ]).process(input).then(function (result) {
+        done(new Error('Parsing should fail.'));
+    }).catch(function (error) {
+        done();
+    });
+};
+
 describe('postcss-modular-scale', function () {
 
     it('should modular scale', function (done) {
@@ -52,4 +60,27 @@ describe('postcss-modular-scale', function () {
         test(input, output, {}, done);
     });
 
+    it('should handle shorthand properties', function (done) {
+        var input = fs.readFileSync(
+            'test/fixtures/shorthand.css',
+            'utf8'
+        );
+        var output = fs.readFileSync(
+            'test/fixtures/shorthand.expected.css',
+            'utf8'
+        );
+        test(input, output, {}, done);
+    });
+
+    it('should report an error on incorrect values', function (done) {
+        var input = fs.readFileSync(
+            'test/fixtures/nonsense-values.css',
+            'utf8'
+        );
+        var output = fs.readFileSync(
+            'test/fixtures/nonsense-values.expected.css',
+            'utf8'
+        );
+        failTest(input, output, {}, done);
+    });
 });


### PR DESCRIPTION
This adds support for modular scale calls in shorthand properties. It does this by parsing the values using the "postcss-value-parser" library. This pull requests also adds two new tests to cover the new support and error cases.
