### PR TITLE
Delete --ms- rules from CSS output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,29 +56,37 @@ module.exports = postcss.plugin(pluginName, function(opts) {
         declarations.forEach(function(decl) {
             var parsedValue = valueParser(decl.value);
 
-            parsedValue.walk(function (node) {
-              if (node.type === 'function' && node.value === 'ms') {
-                if (node.nodes.length === 1 && node.nodes[0].type === 'word') {
-                  var value = parseFloat(node.nodes[0].value);
+            parsedValue.walk(function (node, index, nodes) {
+                if (node.type === 'function' && node.value === 'ms') {
+                    if (node.nodes.length === 1 && node.nodes[0].type === 'word') {
+                        var value = parseFloat(node.nodes[0].value);
 
-                  if (!isNaN(value)) {
-                    var newValue = ms(value);
+                        if (!isNaN(value)) {
+                            var newValue = ms(value);
 
-                    node.type = 'word';
-                    node.value = newValue;
+                            node.type = 'word';
+                            node.value = newValue;
 
-                    result.messages.push({
-                      type: 'modular-scale-result',
-                      plugin: pluginName,
-                      text: 'Modular scale for ' + decl.value + ' is ' + newValue
-                    });
-                  } else {
-                    throw decl.error('Modular scale value should be a number', { plugin: pluginName });
-                  }
-                } else {
-                  throw decl.error('Modular scale value should be a number', { plugin: pluginName });
+                            result.messages.push({
+                                type: 'modular-scale-result',
+                                plugin: pluginName,
+                                text: 'Modular scale for ' + decl.value + ' is ' + newValue
+                            });
+                        } else {
+                            throw decl.error('Modular scale value should be a number', { plugin: pluginName });
+                        }
+                    } else {
+                        throw decl.error('Modular scale value should be a number', { plugin: pluginName });
+                    }
+
+                    // If no length was provided---that is, if the current node
+                    // is followed by a "space" node or the current node is the
+                    // last in the declaration---append the "rem" unit.
+                    var nextIndex = index + 1;
+                    if (nextIndex === nodes.length || nodes[nextIndex].type === 'space') {
+                        node.value += 'rem';
+                    }
                 }
-              }
             });
 
             decl.value = parsedValue.toString();

--- a/index.js
+++ b/index.js
@@ -48,6 +48,12 @@ module.exports = postcss.plugin(pluginName, function(opts) {
 
         });
 
+        css.walkRules(':root', function(rule) {
+            if (rule.nodes.length === 0) {
+                rule.remove();
+            }
+        });
+
         ms = new ModularScale({
             ratios: ratios,
             bases: bases

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = postcss.plugin(pluginName, function(opts) {
 
                 if (decl.prop === '--ms-ratios') {
                     ratios = decl.value.split(',');
+                    decl.remove();
                     result.messages.push({
                         type: 'modular-scale-ratios',
                         plugin: pluginName,
@@ -32,6 +33,7 @@ module.exports = postcss.plugin(pluginName, function(opts) {
 
                 if (decl.prop === '--ms-bases') {
                     bases = decl.value.split(',');
+                    decl.remove();
                     result.messages.push({
                         type: 'modular-scale-bases',
                         plugin: pluginName,
@@ -83,4 +85,3 @@ module.exports = postcss.plugin(pluginName, function(opts) {
         });
     };
 });
-

--- a/test/fixtures/nonsense.expected.css
+++ b/test/fixtures/nonsense.expected.css
@@ -1,6 +1,3 @@
-:root {
-}
-
 .header {
   padding: 6.854rem;
 }

--- a/test/fixtures/nonsense.expected.css
+++ b/test/fixtures/nonsense.expected.css
@@ -1,6 +1,4 @@
 :root {
-  --ms-bases: 'chewbacca', 'happiness';
-  --ms-ratios: 'octopus';
 }
 
 .header {

--- a/test/fixtures/rootless.css
+++ b/test/fixtures/rootless.css
@@ -1,0 +1,8 @@
+:root {
+    --ms-bases: 1;
+    --ms-ratios: 2;
+}
+
+.rootless {
+    font-size: ms(1)rem;
+}

--- a/test/fixtures/rootless.expected.css
+++ b/test/fixtures/rootless.expected.css
@@ -1,0 +1,3 @@
+.rootless {
+    font-size: 2rem;
+}

--- a/test/fixtures/scale.css
+++ b/test/fixtures/scale.css
@@ -6,4 +6,3 @@
 .header {
   font-size: ms(4)rem;
 }
-

--- a/test/fixtures/scale.expected.css
+++ b/test/fixtures/scale.expected.css
@@ -1,6 +1,3 @@
-:root {
-}
-
 .header {
   font-size: 3rem;
 }

--- a/test/fixtures/scale.expected.css
+++ b/test/fixtures/scale.expected.css
@@ -1,9 +1,6 @@
 :root {
-  --ms-bases: 1, 0.75;
-  --ms-ratios: 2;
 }
 
 .header {
   font-size: 3rem;
 }
-

--- a/test/fixtures/shorthand.css
+++ b/test/fixtures/shorthand.css
@@ -6,4 +6,3 @@
 .header {
   padding: ms(1)rem ms(2)rem ms(3)rem ms(4)rem;
 }
-

--- a/test/fixtures/shorthand.expected.css
+++ b/test/fixtures/shorthand.expected.css
@@ -1,6 +1,3 @@
-:root {
-}
-
 .header {
   padding: 2rem 4rem 8rem 16rem;
 }

--- a/test/fixtures/shorthand.expected.css
+++ b/test/fixtures/shorthand.expected.css
@@ -1,9 +1,6 @@
 :root {
-  --ms-bases: 1;
-  --ms-ratios: 2;
 }
 
 .header {
   padding: 2rem 4rem 8rem 16rem;
 }
-

--- a/test/fixtures/unitless.css
+++ b/test/fixtures/unitless.css
@@ -1,0 +1,10 @@
+:root {
+  --ms-bases: 1;
+  --ms-ratios: 2;
+}
+
+.header {
+  border-top: ms(2)px solid #000;
+  font-size: ms(1);
+  padding: ms(1) ms(2)rem ms(3) ms(4)rem;
+}

--- a/test/fixtures/unitless.expected.css
+++ b/test/fixtures/unitless.expected.css
@@ -1,0 +1,8 @@
+:root {
+}
+
+.header {
+  border-top: 4px solid #000;
+  font-size: 2rem;
+  padding: 2rem 4rem 8rem 16rem;
+}

--- a/test/fixtures/unitless.expected.css
+++ b/test/fixtures/unitless.expected.css
@@ -1,6 +1,3 @@
-:root {
-}
-
 .header {
   border-top: 4px solid #000;
   font-size: 2rem;

--- a/test/test.js
+++ b/test/test.js
@@ -95,4 +95,16 @@ describe('postcss-modular-scale', function () {
         );
         failTest(input, output, {}, done);
     });
+
+    it('should remove empty :root rules', function (done) {
+        var input = fs.readFileSync(
+            'test/fixtures/rootless.css',
+            'utf8'
+        );
+        var output = fs.readFileSync(
+            'test/fixtures/rootless.expected.css',
+            'utf8'
+        );
+        test(input, output, {}, done);
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,18 @@ describe('postcss-modular-scale', function () {
         test(input, output, {}, done);
     });
 
+    it('should set unitless values to REMs', function (done) {
+        var input = fs.readFileSync(
+            'test/fixtures/unitless.css',
+            'utf8'
+        );
+        var output = fs.readFileSync(
+            'test/fixtures/unitless.expected.css',
+            'utf8'
+        );
+        test(input, output, {}, done);
+    });
+
     it('should report an error on incorrect values', function (done) {
         var input = fs.readFileSync(
             'test/fixtures/nonsense-values.css',


### PR DESCRIPTION
This PR updates the handling of `--ms-` rules so that they're removed from the generated CSS. The goal is to prevent certain browsers (especially older versions of iOS Safari) from complaining about the invalid rules, and to reduce the size of the CSS output (especially when using modular CSS compilers that require a `:root` declaration in every file).

Also includes an opportunistic fix to #20 that restores the default REM unit in the absence of a declared unit in the CSS. This restores backwards-compatible behavior and prevents the module from becoming unusable with Stylus and Sass. (Both of which, given `ms(1)rem`, will output `ms(1) rem`. Infuriatingly.)